### PR TITLE
Add multi-cluster support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ coverage.html
 
 # Local environment
 .envrc
+.env
 *.log
 migrate.yml

--- a/cmd/vmotion4bosh/main.go
+++ b/cmd/vmotion4bosh/main.go
@@ -17,6 +17,7 @@ type CommandHolder struct {
 	Version             command.VersionCommand `command:"version" description:"Print version information and exit"`
 	CrossVCenterMigrate command.MigrateVM      `command:"migrate-vm" description:"Migrates a vm from one vcenter to another"`
 	Migrate             command.Migrate        `command:"migrate" description:"Migrates an entire foundation from one vcenter to another"`
+	Revert              command.Revert         `command:"revert" description:"Reverts a prior migration back to the source vcenter"`
 }
 
 var Command CommandHolder

--- a/command/migrate_vm.go
+++ b/command/migrate_vm.go
@@ -24,7 +24,6 @@ type MigrateVM struct {
 
 	TargetHost         string `long:"target-vcenter-host" env:"TARGET_VCENTER_HOST"  description:"target vcenter hostname" required:"true"`
 	TargetDatacenter   string `long:"target-datacenter" description:"target datacenter name (where you want the vm to go)" required:"true"`
-	TargetCluster      string `long:"target-cluster" description:"target cluster name (where you want the vm to go)" required:"true"`
 	TargetResourcePool string `long:"target-resourcepool" description:"target resource pool name"`
 	TargetUsername     string `long:"target-username" env:"TARGET_USERNAME"  description:"username for target vcenter" required:"true"`
 	TargetPassword     string `long:"target-password" env:"TARGET_PASSWORD"  description:"password for target vcenter" required:"true"`
@@ -32,6 +31,7 @@ type MigrateVM struct {
 
 	NetworkMapping   map[string]string `long:"network-mapping" description:"source to target network name mappings"`
 	DatastoreMapping map[string]string `long:"datastore-mapping" description:"source to target datastore name mappings" required:"true"`
+	ClusterMapping   map[string]string `long:"cluster-mapping" description:"source to target cluster name mappings" required:"true"`
 
 	DryRun bool `long:"dry-run"  description:"does not perform any migration operations when true"`
 	Debug  bool `long:"debug"  description:"sets log level to debug"`
@@ -51,8 +51,8 @@ func (m *MigrateVM) Execute([]string) error {
 		converter.NewMappedNetwork(m.NetworkMapping),
 		converter.NewExplicitResourcePool(m.TargetResourcePool),
 		converter.NewMappedDatastore(m.DatastoreMapping),
-		m.TargetDatacenter,
-		m.TargetCluster)
+		converter.NewMappedCluster(m.ClusterMapping),
+		m.TargetDatacenter)
 
 	destinationHostPool := vcenter.NewHostPool(destinationVCenter, m.TargetDatacenter)
 	err := destinationHostPool.Initialize(ctx)

--- a/command/revert.go
+++ b/command/revert.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package command
+
+import (
+	"context"
+	"github.com/vmware-tanzu/vmotion-migration-tool-for-bosh-deployments/pkg/log"
+	"github.com/vmware-tanzu/vmotion-migration-tool-for-bosh-deployments/pkg/migrate"
+)
+
+type Revert struct {
+	Migrate
+}
+
+// Execute - runs the migration in reverse
+func (r *Revert) Execute([]string) error {
+	log.Initialize(r.Debug)
+	ctx := context.Background()
+
+	c, err := r.combinedConfig()
+	if err != nil {
+		return err
+	}
+
+	return migrate.RunFoundationMigrationWithConfig(c.Reversed(), ctx)
+}

--- a/docs/migrate-compute.md
+++ b/docs/migrate-compute.md
@@ -40,6 +40,11 @@ datastores:
 networks:
   PAS-Deployment-01: TAS-Deployment
   PAS-Services-01: TAS-Services
+  
+clusters:
+  PAS-Cluster-AZ1: TAS-AZ1
+  PAS-Cluster-AZ2: TAS-AZ2
+  PAS-Cluster-AZ3: TAS-AZ3
 
 resource_pools:
   pas-az1: tas-az1
@@ -63,10 +68,9 @@ target:
     username: administrator@vsphere.local
     insecure: true
   datacenter: Irvine
-  cluster: Cluster01
 ```
 
-The datastores, networks, and resource_pools sections map the old vCenter objects on the left (the yaml key) to the new
+The datastores, networks, clusters, and resource_pools sections map the old vCenter objects on the left (the yaml key) to the new
 vCenter objects on the right. The migration requires the same number of resource pools and networks. The target networks must be in the
 same broadcast domain so the VMs can use the same IP addresses.
 
@@ -78,19 +82,24 @@ The `additional_vms` section is optional, however it's recommended that you use 
 and your Operations Manager VM (if using TAS). Just add each VM's name to the list to have vmotion4bosh migrate the
 listed VMs.
 
-The `datastores` section maps the source datastores to the destination 
+The required `datastores` section maps the source datastores to the destination 
 datastores. Each yaml key on the left is the name of the source datastore 
 and the value on the right is the destination datastore name. All datastores 
 used by any migrated VM must be present. If migrating to the same storage on 
 the destination you will still need to include the datastore mapping, for 
 example `ds1: ds1`
 
-The `network` section maps the source networks to the destination networks.
+The required `networks` section maps the source networks to the destination networks.
 Each yaml key on the left is the name of the source network and the value
 on the right is the destination network name. All networks used by any 
 migrated VM must be present. If migrating to the same network on the
 destination you will still need to include the network mapping, for example
 `net1: net1`
+
+The required `clusters` section maps the source cluster to the destination cluster.
+Each yaml key on the left is the name of the source cluster and the value
+on the right is the destination cluster name. All clusters used by any
+migrated VM must be present.
 
 The optional `resource_pools` section maps the source resource pools to the destination
 resource pools. Each yaml key on the left is the name of the source resource

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,7 +57,6 @@ type Bosh struct {
 type Target struct {
 	VCenter
 	Datacenter string `yaml:"datacenter"`
-	Cluster    string `yaml:"cluster"` // assumes single cluster foundation
 }
 
 type Source struct {
@@ -74,6 +73,7 @@ type Config struct {
 	ResourcePoolMap map[string]string `yaml:"resource_pools"`
 	NetworkMap      map[string]string `yaml:"networks"`
 	DatastoreMap    map[string]string `yaml:"datastores"`
+	ClusterMap      map[string]string `yaml:"clusters"`
 	AdditionalVMs   []string          `yaml:"additional_vms"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,6 +77,62 @@ type Config struct {
 	AdditionalVMs   []string          `yaml:"additional_vms"`
 }
 
+func (c Config) Reversed() Config {
+	rc := Config{
+		Source: Source{
+			VCenter: VCenter{
+				Host:     c.Target.Host,
+				Username: c.Target.Username,
+				Password: c.Target.Password,
+				Insecure: c.Target.Insecure,
+			},
+			Datacenter: c.Target.Datacenter,
+		},
+		Target: Target{
+			VCenter: VCenter{
+				Host:     c.Source.Host,
+				Username: c.Source.Username,
+				Password: c.Source.Password,
+				Insecure: c.Source.Insecure,
+			},
+			Datacenter: c.Source.Datacenter,
+		},
+		DryRun:         c.DryRun,
+		WorkerPoolSize: c.WorkerPoolSize,
+		AdditionalVMs:  c.AdditionalVMs,
+	}
+
+	rc.ResourcePoolMap = make(map[string]string, len(c.ResourcePoolMap))
+	for k, v := range c.ResourcePoolMap {
+		rc.ResourcePoolMap[v] = k
+	}
+
+	rc.NetworkMap = make(map[string]string, len(c.NetworkMap))
+	for k, v := range c.NetworkMap {
+		rc.NetworkMap[v] = k
+	}
+
+	rc.DatastoreMap = make(map[string]string, len(c.DatastoreMap))
+	for k, v := range c.DatastoreMap {
+		rc.DatastoreMap[v] = k
+	}
+
+	rc.ClusterMap = make(map[string]string, len(c.ClusterMap))
+	for k, v := range c.ClusterMap {
+		rc.ClusterMap[v] = k
+	}
+
+	if c.Bosh != nil {
+		rc.Bosh = &Bosh{
+			Host:         c.Bosh.Host,
+			ClientID:     c.Bosh.ClientID,
+			ClientSecret: c.Bosh.ClientSecret,
+		}
+	}
+
+	return rc
+}
+
 // String used primarily for debug logging
 func (c Config) String() string {
 	// easier to compare as yaml

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,7 +22,7 @@ func TestConfig(t *testing.T) {
 			VCenter: config.VCenter{
 				Host:     "sc3-m01-vc01.plat-svcs.pez.vmware.com",
 				Username: "administrator@vsphere.local",
-				Insecure: false,
+				Insecure: true,
 			},
 			Datacenter: "Datacenter1",
 		},
@@ -30,7 +30,7 @@ func TestConfig(t *testing.T) {
 			VCenter: config.VCenter{
 				Host:     "sc3-m01-vc02.plat-svcs.pez.vmware.com",
 				Username: "administrator2@vsphere.local",
-				Insecure: false,
+				Insecure: true,
 			},
 			Datacenter: "Datacenter2",
 		},
@@ -62,6 +62,58 @@ func TestConfig(t *testing.T) {
 		},
 	}
 	require.Equal(t, expected, c)
+}
+
+func TestReverseConfig(t *testing.T) {
+	c, err := config.NewConfigFromFile("./fixtures/config.yml")
+	require.NoError(t, err)
+	expected := config.Config{
+		WorkerPoolSize: 2,
+		Target: config.Target{
+			VCenter: config.VCenter{
+				Host:     "sc3-m01-vc01.plat-svcs.pez.vmware.com",
+				Username: "administrator@vsphere.local",
+				Insecure: true,
+			},
+			Datacenter: "Datacenter1",
+		},
+		Source: config.Source{
+			VCenter: config.VCenter{
+				Host:     "sc3-m01-vc02.plat-svcs.pez.vmware.com",
+				Username: "administrator2@vsphere.local",
+				Insecure: true,
+			},
+			Datacenter: "Datacenter2",
+		},
+		Bosh: &config.Bosh{
+			Host:     "10.1.3.12",
+			ClientID: "ops_manager",
+		},
+		NetworkMap: map[string]string{
+			"TAS":      "PAS-Deployment",
+			"Services": "PAS-Services",
+		},
+		ResourcePoolMap: map[string]string{
+			"tas-az1": "pas-az1",
+			"tas-az2": "pas-az2",
+			"tas-az3": "pas-az3",
+		},
+		DatastoreMap: map[string]string{
+			"ssd-ds1": "ds1",
+			"ssd-ds2": "ds2",
+		},
+		ClusterMap: map[string]string{
+			"tanzu-1": "cf1",
+			"tanzu-2": "cf2",
+			"tanzu-3": "cf3",
+		},
+		AdditionalVMs: []string{
+			"vm-2b8bc4a2-90c8-4715-9bc7-ddf64560fdd5",
+			"ops-manager-2.10.27",
+		},
+	}
+	rc := c.Reversed()
+	require.Equal(t, expected, rc)
 }
 
 func TestConfigWithSameTargetVCenter(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,7 +32,6 @@ func TestConfig(t *testing.T) {
 				Username: "administrator2@vsphere.local",
 				Insecure: false,
 			},
-			Cluster:    "Cluster01",
 			Datacenter: "Datacenter2",
 		},
 		Bosh: &config.Bosh{
@@ -51,6 +50,11 @@ func TestConfig(t *testing.T) {
 		DatastoreMap: map[string]string{
 			"ds1": "ssd-ds1",
 			"ds2": "ssd-ds2",
+		},
+		ClusterMap: map[string]string{
+			"cf1": "tanzu-1",
+			"cf2": "tanzu-2",
+			"cf3": "tanzu-3",
 		},
 		AdditionalVMs: []string{
 			"vm-2b8bc4a2-90c8-4715-9bc7-ddf64560fdd5",
@@ -79,7 +83,6 @@ func TestConfigWithSameTargetVCenter(t *testing.T) {
 				Username: "administrator@vsphere.local",
 				Insecure: false,
 			},
-			Cluster:    "Cluster01",
 			Datacenter: "Datacenter2",
 		},
 		Bosh: &config.Bosh{
@@ -98,6 +101,11 @@ func TestConfigWithSameTargetVCenter(t *testing.T) {
 		DatastoreMap: map[string]string{
 			"ds1": "ssd-ds1",
 			"ds2": "ssd-ds2",
+		},
+		ClusterMap: map[string]string{
+			"cf1": "tanzu-1",
+			"cf2": "tanzu-2",
+			"cf3": "tanzu-3",
 		},
 	}
 	require.Equal(t, expected, c)

--- a/pkg/config/fixtures/config-minimal.yml
+++ b/pkg/config/fixtures/config-minimal.yml
@@ -5,6 +5,9 @@ datastores:
 networks:
   PAS-Deployment: TAS
 
+clusters:
+  cf1: tanzu-1
+
 bosh:
   host: 10.1.3.12
   client_id: ops_manager
@@ -17,4 +20,3 @@ source:
 
 target:
   datacenter: Datacenter2
-  cluster: Cluster01

--- a/pkg/config/fixtures/config-no-bosh.yml
+++ b/pkg/config/fixtures/config-no-bosh.yml
@@ -5,6 +5,9 @@ datastores:
 networks:
   PAS-Deployment: TAS
 
+clusters:
+  cf1: tanzu-1
+
 additional_vms:
   - opsmanager
 

--- a/pkg/config/fixtures/config-same-vcenter.yml
+++ b/pkg/config/fixtures/config-same-vcenter.yml
@@ -9,6 +9,11 @@ networks:
   PAS-Deployment: TAS
   PAS-Services: Services
 
+clusters:
+  cf1: tanzu-1
+  cf2: tanzu-2
+  cf3: tanzu-3
+
 resource_pools:
   pas-az1: tas-az1
   pas-az2: tas-az2

--- a/pkg/config/fixtures/config.yml
+++ b/pkg/config/fixtures/config.yml
@@ -9,6 +9,11 @@ networks:
   PAS-Deployment: TAS
   PAS-Services: Services
 
+clusters:
+  cf1: tanzu-1
+  cf2: tanzu-2
+  cf3: tanzu-3
+
 resource_pools:
   pas-az1: tas-az1
   pas-az2: tas-az2

--- a/pkg/config/fixtures/config.yml
+++ b/pkg/config/fixtures/config.yml
@@ -31,11 +31,13 @@ source:
   vcenter:
     host: sc3-m01-vc01.plat-svcs.pez.vmware.com
     username: administrator@vsphere.local
+    insecure: true
   datacenter: Datacenter1
 
 target:
   vcenter:
     host: sc3-m01-vc02.plat-svcs.pez.vmware.com
     username: administrator2@vsphere.local
+    insecure: true
   datacenter: Datacenter2
   cluster: Cluster01

--- a/pkg/config/fixtures/config_marshalled.yml
+++ b/pkg/config/fixtures/config_marshalled.yml
@@ -12,7 +12,6 @@ target:
         password: ""
         insecure: false
     datacenter: Datacenter2
-    cluster: Cluster01
 bosh:
     host: 10.1.3.12
     client_id: ops_manager
@@ -29,6 +28,10 @@ networks:
 datastores:
     ds1: ssd-ds1
     ds2: ssd-ds2
+clusters:
+    cf1: tanzu-1
+    cf2: tanzu-2
+    cf3: tanzu-3
 additional_vms:
     - vm-2b8bc4a2-90c8-4715-9bc7-ddf64560fdd5
     - ops-manager-2.10.27

--- a/pkg/config/fixtures/config_marshalled.yml
+++ b/pkg/config/fixtures/config_marshalled.yml
@@ -3,14 +3,14 @@ source:
         host: sc3-m01-vc01.plat-svcs.pez.vmware.com
         username: administrator@vsphere.local
         password: ""
-        insecure: false
+        insecure: true
     datacenter: Datacenter1
 target:
     vcenter:
         host: sc3-m01-vc02.plat-svcs.pez.vmware.com
         username: administrator2@vsphere.local
         password: ""
-        insecure: false
+        insecure: true
     datacenter: Datacenter2
 bosh:
     host: 10.1.3.12

--- a/pkg/migrate/converter/converter_test.go
+++ b/pkg/migrate/converter/converter_test.go
@@ -48,7 +48,10 @@ func TestExplicitConverter(t *testing.T) {
 	rp := converter.NewExplicitResourcePool("tRP")
 	net := converter.NewEmptyMappedNetwork().Add("sN", "tN")
 	ds := converter.NewEmptyMappedDatastore().Add("sDS", "tDS")
-	c := converter.New(net, rp, ds, "tDC", "tC")
+	cm := converter.NewMappedCluster(map[string]string{
+		"sC": "tC",
+	})
+	c := converter.New(net, rp, ds, cm, "tDC")
 	for _, tt := range explicitTests {
 		t.Run(tt.name, func(t *testing.T) {
 			spec, err := c.TargetSpec(tt.in)
@@ -261,7 +264,10 @@ func TestMappedConverter(t *testing.T) {
 		"sDS":  "tDS",
 		"sDS2": "tDS2",
 	})
-	c := converter.New(net, rp, ds, "tDC", "tC")
+	cm := converter.NewMappedCluster(map[string]string{
+		"sC": "tC",
+	})
+	c := converter.New(net, rp, ds, cm, "tDC")
 	for _, tt := range mappedTests {
 		t.Run(tt.name, func(t *testing.T) {
 			spec, err := c.TargetSpec(tt.in)
@@ -336,7 +342,10 @@ func TestMappedConverterNoResourcePools(t *testing.T) {
 	ds := converter.NewMappedDatastore(map[string]string{
 		"sDS": "tDS",
 	})
-	c := converter.New(net, rp, ds, "tDC", "tC")
+	cm := converter.NewMappedCluster(map[string]string{
+		"sC": "tC",
+	})
+	c := converter.New(net, rp, ds, cm, "tDC")
 	for _, tt := range mappedTestsNoRP {
 		t.Run(tt.name, func(t *testing.T) {
 			spec, err := c.TargetSpec(tt.in)

--- a/pkg/migrate/converter/mapped_cluster.go
+++ b/pkg/migrate/converter/mapped_cluster.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package converter
+
+import (
+	"fmt"
+
+	"github.com/vmware-tanzu/vmotion-migration-tool-for-bosh-deployments/pkg/vcenter"
+)
+
+type MappedCluster struct {
+	clusterMap map[string]string
+}
+
+func NewMappedCluster(clusterMap map[string]string) *MappedCluster {
+	return &MappedCluster{
+		clusterMap: clusterMap,
+	}
+}
+
+func (c *MappedCluster) TargetClusterFromSource(sourceCluster string) (string, error) {
+	targetCluster, ok := c.clusterMap[sourceCluster]
+	if !ok {
+		return "", fmt.Errorf("could not find a target cluster for VM in source cluster %s: "+
+			"ensure you add a corresponding cluster mapping to the config file",
+			sourceCluster)
+	}
+	return targetCluster, nil
+}
+
+func (c *MappedCluster) TargetCluster(sourceVM *vcenter.VM) (string, error) {
+	targetCluster, ok := c.clusterMap[sourceVM.Cluster]
+	if !ok {
+		return "", fmt.Errorf("could not find a target cluster for VM %s in source cluster %s: "+
+			"ensure you add a corresponding cluster mapping to the config file",
+			sourceVM.Name, sourceVM.ResourcePool)
+	}
+	return targetCluster, nil
+}

--- a/pkg/migrate/converter/mapped_cluster.go
+++ b/pkg/migrate/converter/mapped_cluster.go
@@ -15,10 +15,19 @@ type MappedCluster struct {
 	clusterMap map[string]string
 }
 
+func NewEmptyMappedCluster() *MappedCluster {
+	return NewMappedCluster(map[string]string{})
+}
+
 func NewMappedCluster(clusterMap map[string]string) *MappedCluster {
 	return &MappedCluster{
 		clusterMap: clusterMap,
 	}
+}
+
+func (c *MappedCluster) Add(srcCluster, targetCluster string) *MappedCluster {
+	c.clusterMap[srcCluster] = targetCluster
+	return c
 }
 
 func (c *MappedCluster) TargetClusterFromSource(sourceCluster string) (string, error) {

--- a/pkg/migrate/foundation.go
+++ b/pkg/migrate/foundation.go
@@ -78,8 +78,8 @@ func RunFoundationMigrationWithConfig(c config.Config, ctx context.Context) erro
 		converter.NewMappedNetwork(c.NetworkMap),
 		converter.NewMappedResourcePool(c.ResourcePoolMap),
 		converter.NewMappedDatastore(c.DatastoreMap),
-		c.Target.Datacenter,
-		c.Target.Cluster)
+		converter.NewMappedCluster(c.ClusterMap),
+		c.Target.Datacenter)
 
 	destinationHostPool := vcenter.NewHostPool(destinationVCenter, c.Target.Datacenter)
 	err := destinationHostPool.Initialize(ctx)

--- a/pkg/migrate/foundation_test.go
+++ b/pkg/migrate/foundation_test.go
@@ -83,8 +83,8 @@ func TestMigrateFoundation(t *testing.T) {
 		converter.NewEmptyMappedNetwork().Add("Net1", "Net2"),
 		converter.NewExplicitResourcePool("RP2"),
 		converter.NewEmptyMappedDatastore().Add("DS1", "DS2"),
-		"DC2",
-		"Cluster2")
+		converter.NewEmptyMappedCluster().Add("Cluster1", "Cluster2"),
+		"DC2")
 
 	vmRelocator := &migratefakes.FakeVMRelocator{}
 
@@ -103,6 +103,7 @@ func TestMigrateFoundation(t *testing.T) {
 	require.Equal(t, "sc-1", targetSpec.Name)
 	require.Equal(t, "DC2", targetSpec.Datacenter)
 	require.Equal(t, "RP2", targetSpec.ResourcePool)
+	require.Equal(t, "Cluster2", targetSpec.Cluster)
 	require.Equal(t, map[string]string{"DS1": "DS2"}, targetSpec.Datastores)
 	require.Equal(t, map[string]string{}, targetSpec.Networks)
 
@@ -111,6 +112,7 @@ func TestMigrateFoundation(t *testing.T) {
 	require.Equal(t, "vm1", targetSpec.Name)
 	require.Equal(t, "DC2", targetSpec.Datacenter)
 	require.Equal(t, "RP2", targetSpec.ResourcePool)
+	require.Equal(t, "Cluster2", targetSpec.Cluster)
 	require.Equal(t, map[string]string{"DS1": "DS2"}, targetSpec.Datastores)
 	require.Equal(t, map[string]string{"Net1": "Net2"}, targetSpec.Networks)
 
@@ -119,6 +121,7 @@ func TestMigrateFoundation(t *testing.T) {
 	require.Equal(t, "vm2", targetSpec.Name)
 	require.Equal(t, "DC2", targetSpec.Datacenter)
 	require.Equal(t, "RP2", targetSpec.ResourcePool)
+	require.Equal(t, "Cluster2", targetSpec.Cluster)
 	require.Equal(t, map[string]string{"DS1": "DS2"}, targetSpec.Datastores)
 	require.Equal(t, map[string]string{"Net1": "Net2"}, targetSpec.Networks)
 
@@ -127,6 +130,7 @@ func TestMigrateFoundation(t *testing.T) {
 	require.Equal(t, "additional-vm1", targetSpec.Name)
 	require.Equal(t, "DC2", targetSpec.Datacenter)
 	require.Equal(t, "RP2", targetSpec.ResourcePool)
+	require.Equal(t, "Cluster2", targetSpec.Cluster)
 	require.Equal(t, map[string]string{"DS1": "DS2"}, targetSpec.Datastores)
 	require.Equal(t, map[string]string{"Net1": "Net2"}, targetSpec.Networks)
 }

--- a/pkg/migrate/migratefakes/fake_vcenter_client.go
+++ b/pkg/migrate/migratefakes/fake_vcenter_client.go
@@ -10,13 +10,12 @@ import (
 )
 
 type FakeVCenterClient struct {
-	FindVMStub        func(context.Context, string, string, string) (*vcenter.VM, error)
+	FindVMStub        func(context.Context, string, string) (*vcenter.VM, error)
 	findVMMutex       sync.RWMutex
 	findVMArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
-		arg4 string
 	}
 	findVMReturns struct {
 		result1 *vcenter.VM
@@ -40,21 +39,20 @@ type FakeVCenterClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeVCenterClient) FindVM(arg1 context.Context, arg2 string, arg3 string, arg4 string) (*vcenter.VM, error) {
+func (fake *FakeVCenterClient) FindVM(arg1 context.Context, arg2 string, arg3 string) (*vcenter.VM, error) {
 	fake.findVMMutex.Lock()
 	ret, specificReturn := fake.findVMReturnsOnCall[len(fake.findVMArgsForCall)]
 	fake.findVMArgsForCall = append(fake.findVMArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
-		arg4 string
-	}{arg1, arg2, arg3, arg4})
+	}{arg1, arg2, arg3})
 	stub := fake.FindVMStub
 	fakeReturns := fake.findVMReturns
-	fake.recordInvocation("FindVM", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("FindVM", []interface{}{arg1, arg2, arg3})
 	fake.findVMMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -68,17 +66,17 @@ func (fake *FakeVCenterClient) FindVMCallCount() int {
 	return len(fake.findVMArgsForCall)
 }
 
-func (fake *FakeVCenterClient) FindVMCalls(stub func(context.Context, string, string, string) (*vcenter.VM, error)) {
+func (fake *FakeVCenterClient) FindVMCalls(stub func(context.Context, string, string) (*vcenter.VM, error)) {
 	fake.findVMMutex.Lock()
 	defer fake.findVMMutex.Unlock()
 	fake.FindVMStub = stub
 }
 
-func (fake *FakeVCenterClient) FindVMArgsForCall(i int) (context.Context, string, string, string) {
+func (fake *FakeVCenterClient) FindVMArgsForCall(i int) (context.Context, string, string) {
 	fake.findVMMutex.RLock()
 	defer fake.findVMMutex.RUnlock()
 	argsForCall := fake.findVMArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeVCenterClient) FindVMReturns(result1 *vcenter.VM, result2 error) {

--- a/pkg/migrate/vm_migrator.go
+++ b/pkg/migrate/vm_migrator.go
@@ -22,7 +22,7 @@ type VMRelocator interface {
 //counterfeiter:generate . VCenterClient
 type VCenterClient interface {
 	HostName() string
-	FindVM(ctx context.Context, datacenter, cluster, vmName string) (*vcenter.VM, error)
+	FindVM(ctx context.Context, datacenter, vmName string) (*vcenter.VM, error)
 }
 
 type VMMigrator struct {
@@ -49,11 +49,11 @@ func (m *VMMigrator) Migrate(ctx context.Context, srcDatacenter, srcVMName strin
 		srcVMName, m.sourceVCenter.HostName(), m.targetVCenter.HostName())
 
 	// find the VM to migrate in the source
-	srcVM, err := m.sourceVCenter.FindVM(ctx, srcDatacenter, "", srcVMName)
+	srcVM, err := m.sourceVCenter.FindVM(ctx, srcDatacenter, srcVMName)
 	if err != nil {
 		var e *vcenter.VMNotFoundError
 		if errors.As(err, &e) {
-			destVM, _ := m.targetVCenter.FindVM(ctx, m.sourceVMConverter.TargetDatacenter(), "", srcVMName)
+			destVM, _ := m.targetVCenter.FindVM(ctx, m.sourceVMConverter.TargetDatacenter(), srcVMName)
 			if destVM != nil {
 				m.updatableStdout.PrintUpdatablef(srcVMName, "%s - already migrated, skipping", srcVMName)
 			} else {

--- a/pkg/migrate/vm_migrator.go
+++ b/pkg/migrate/vm_migrator.go
@@ -48,19 +48,17 @@ func (m *VMMigrator) Migrate(ctx context.Context, srcDatacenter, srcVMName strin
 	l.Infof("Migrating VM %s from %s to %s",
 		srcVMName, m.sourceVCenter.HostName(), m.targetVCenter.HostName())
 
-	destVM, _ := m.targetVCenter.FindVM(ctx, m.sourceVMConverter.TargetDatacenter(), m.sourceVMConverter.TargetCluster(), srcVMName)
-	if destVM != nil {
-		m.updatableStdout.PrintUpdatablef(srcVMName, "%s - already migrated, skipping", srcVMName)
-		return nil
-	}
-
 	// find the VM to migrate in the source
 	srcVM, err := m.sourceVCenter.FindVM(ctx, srcDatacenter, "", srcVMName)
 	if err != nil {
 		var e *vcenter.VMNotFoundError
 		if errors.As(err, &e) {
-			m.updatableStdout.PrintUpdatablef(srcVMName, "%s - not found in source vCenter, skipping", srcVMName)
-			// assume it's already been previously migrated or deleted (handle missing VMs via BOSH)
+			destVM, _ := m.targetVCenter.FindVM(ctx, m.sourceVMConverter.TargetDatacenter(), "", srcVMName)
+			if destVM != nil {
+				m.updatableStdout.PrintUpdatablef(srcVMName, "%s - already migrated, skipping", srcVMName)
+			} else {
+				m.updatableStdout.PrintUpdatablef(srcVMName, "%s - not found in source vCenter, skipping", srcVMName)
+			}
 			return nil
 		}
 		return err

--- a/pkg/vcenter/client.go
+++ b/pkg/vcenter/client.go
@@ -61,7 +61,7 @@ func (c *Client) HostName() string {
 	return c.Host
 }
 
-func (c *Client) FindVM(ctx context.Context, datacenter, cluster, vmName string) (*VM, error) {
+func (c *Client) FindVM(ctx context.Context, datacenter, vmName string) (*VM, error) {
 	l := log.FromContext(ctx)
 
 	client, err := c.getOrCreateUnderlyingClient(ctx)
@@ -78,32 +78,13 @@ func (c *Client) FindVM(ctx context.Context, datacenter, cluster, vmName string)
 		return nil, err
 	}
 
-	// if cluster was specified ensure this VM is part of the specified cluster
-	foundCluster := false
-	if cluster != "" {
-		l.Debugf("Finding VM %s in cluster %s", vmName, cluster)
-		hosts, err := f.HostsInCluster(ctx, cluster)
-		if err != nil {
-			return nil, err
-		}
-		for _, h := range hosts {
-			vmHost, err := vm.HostSystem(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("could not get host system for VM %s: %w", vmName, err)
-			}
-			if h.Reference().Value == vmHost.Reference().Value {
-				foundCluster = true
-				break
-			}
-		}
-		if !foundCluster {
-			l.Debugf("VM %s was not found in cluster %s", vmName, cluster)
-			return nil, NewVMNotFoundError(vmName)
-		}
-	}
-
 	l.Debugf("Getting VM %s resource pool", vmName)
 	rp, err := vm.ResourcePool(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster, err := f.Cluster(ctx, vm)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +107,7 @@ func (c *Client) FindVM(ctx context.Context, datacenter, cluster, vmName string)
 	return &VM{
 		Name:         vmName,
 		Datacenter:   datacenter,
-		Cluster:      cluster, // TODO: always populate this to support multi-cluster migrations
+		Cluster:      cluster,
 		ResourcePool: pool,
 		Networks:     nets,
 		Disks:        disks,

--- a/pkg/vcenter/finder_test.go
+++ b/pkg/vcenter/finder_test.go
@@ -49,6 +49,34 @@ func TestVirtualMachine(t *testing.T) {
 	})
 }
 
+func TestCluster(t *testing.T) {
+	VPXTest(func(ctx context.Context, client *govmomi.Client) {
+		finder := vcenter.NewFinder("DC0", client)
+
+		t.Run("Find cluster", func(t *testing.T) {
+			vm0, err := finder.VirtualMachine(ctx, "DC0_C0_RP0_VM0")
+			require.NoError(t, err)
+			cluster, err := finder.Cluster(ctx, vm0)
+			require.NoError(t, err)
+			require.Equal(t, "DC0_C0", cluster)
+
+			vm1, err := finder.VirtualMachine(ctx, "DC0_C0_RP0_VM1")
+			require.NoError(t, err)
+			cluster, err = finder.Cluster(ctx, vm1)
+			require.NoError(t, err)
+			require.Equal(t, "DC0_C0", cluster)
+		})
+
+		t.Run("Non-existent cluster", func(t *testing.T) {
+			vm0, err := finder.VirtualMachine(ctx, "DC0_H0_VM0")
+			require.NoError(t, err)
+			_, err = finder.Cluster(ctx, vm0)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "found unsupported compute type ComputeResource")
+		})
+	})
+}
+
 func TestResourcePool(t *testing.T) {
 	VPXTest(func(ctx context.Context, client *govmomi.Client) {
 		finder := vcenter.NewFinder("DC0", client)


### PR DESCRIPTION
Adds support for multiple clusters/AZs by mapping VMs to the appropriate cluster.

This also adds support for the new `revert` command which does the same thing as `migrate` but in reverse. This is useful for testing or fail back scenarios.